### PR TITLE
CI/Modules/publish: replaced Publish Projects task with a powershell …

### DIFF
--- a/V1/CI/Modules/publish.yaml
+++ b/V1/CI/Modules/publish.yaml
@@ -7,21 +7,17 @@ parameters:
   default: 'Release'
 
 steps:
-
-# I publish the project
-- task: DotNetCoreCLI@2
-  displayName: '.Net Core CLI - Publish Projects'
+- task: PowerShell@2
+  displayName: 'Publish Projects'
   inputs:
-    command: publish
-    publishWebProjects: False
-    projects: ${{ Parameters.Projects }}
-    arguments: '--configuration ${{ Parameters.BuildConfiguration }} --output $(build.artifactstagingdirectory)'
-    zipAfterPublish: True
+    targetType: 'inline'
+    script: |
+      mkdir $(Build.ArtifactStagingDirectory)/temp
+      dotnet publish ${{ Parameters.Projects }} --configuration ${{ Parameters.BuildConfiguration }} --output $(Build.ArtifactStagingDirectory)/temp
+      Compress-Archive $(Build.ArtifactStagingDirectory)/temp/* $(Build.ArtifactStagingDirectory)/drop.zip -Force
+      rm $(Build.ArtifactStagingDirectory)/temp -r
 
-# I publish the artifact
-- task: PublishPipelineArtifact@1
-  displayName: 'Artifacts - Publish Projects'
-  inputs:
-    targetPath: '$(Build.ArtifactStagingDirectory)' 
-    artifactName: 'drop'
-  condition: succeededOrFailed()
+- publish: '$(Build.ArtifactStagingDirectory)'
+  displayName: 'Publish Artifact'
+  artifact: $(Build.DefinitionName)
+  


### PR DESCRIPTION
…script (there were some compatibility issues with Nuget versione and .NET >= 5) and updated publish task with a most efficient one (- publish:)