### PR TITLE
fix: publishWebProjects e appType parametrizzato per Function App

### DIFF
--- a/V3/CD/Agnostic/deploy-azure-functionApp.yaml
+++ b/V3/CD/Agnostic/deploy-azure-functionApp.yaml
@@ -29,6 +29,8 @@
 #   ciSourceBranch           → branch CI da cui scaricare l'artifact
 #                              (default: '$(Build.SourceBranch)', override per trigger manuale
 #                               es. 'refs/heads/dev')
+#   appType                  → tipo di Function App
+#                              (default: 'functionAppLinux')
 #
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -58,6 +60,12 @@ parameters:
     displayName: 'Branch CI da cui scaricare l''artifact (default: branch corrente)'
     type: string
     default: '$(Build.SourceBranch)'
+
+  - name: appType
+    displayName: 'Tipo di Function App'
+    type: string
+    default: 'functionAppLinux'
+    # Valori: 'functionApp' (Windows) | 'functionAppLinux' (Linux)
 
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -100,3 +108,4 @@ stages:
                     azureServiceConnection: '${{ parameters.azureServiceConnection }}'
                     functionAppName: '${{ parameters.functionAppName }}'
                     packagePath: '$(Pipeline.Workspace)/${{ parameters.ciPipelineResourceAlias }}/**/*.zip'
+                    appType: '${{ parameters.appType }}'

--- a/V3/CD/Common/Steps/functionApp-deploy.yaml
+++ b/V3/CD/Common/Steps/functionApp-deploy.yaml
@@ -13,6 +13,8 @@
 #   functionAppName        → nome completo Function App (es. func-myapp-be-staging)
 #   packagePath            → glob path del .zip da deployare
 #                            (default: variabile $(packagePath))
+#   appType                → tipo di Function App
+#                            (default: 'functionAppLinux')
 #
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -27,6 +29,11 @@ parameters:
     type: string
     default: '$(packagePath)'
 
+  - name: appType
+    type: string
+    default: 'functionAppLinux'
+    # Valori: 'functionApp' (Windows) | 'functionAppLinux' (Linux)
+
 # ─────────────────────────────────────────────────────────────────────────────
 
 steps:
@@ -34,7 +41,7 @@ steps:
     displayName: 'Deploy su Function App — ${{ parameters.functionAppName }}'
     inputs:
       azureSubscription: '${{ parameters.azureServiceConnection }}'
-      appType: 'functionApp'
+      appType: '${{ parameters.appType }}'
       appName: '${{ parameters.functionAppName }}'
       package: '${{ parameters.packagePath }}'
       deploymentMethod: 'zipDeploy'

--- a/V3/CI/Common/Steps/dotnet-publish.yaml
+++ b/V3/CI/Common/Steps/dotnet-publish.yaml
@@ -88,6 +88,7 @@ steps:
     displayName: 'DotNet Publish'
     inputs:
       command: 'publish'
+      publishWebProjects: false
       projects: '${{ parameters.publishProject }}'
       arguments: >
         --configuration ${{ parameters.buildConfiguration }}


### PR DESCRIPTION
- dotnet-publish.yaml: aggiunto publishWebProjects: false per evitare
  che DotNetCoreCLI@2 ignori il parametro projects e pubblichi tutti
  i progetti web trovati nel workspace
- functionApp-deploy.yaml: aggiunto parametro appType (default:
  functionAppLinux) e sostituito valore hardcoded 'functionApp'
- deploy-azure-functionApp.yaml: aggiunto parametro appType e passato
  al template functionApp-deploy.yaml