### PR TITLE
feat: add optional SonarCloud analysis to quality pipelines

### DIFF
--- a/V3/CI/Agnostic/quality-angular.yaml
+++ b/V3/CI/Agnostic/quality-angular.yaml
@@ -49,4 +49,4 @@ stages:
               sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
               sonarOrganization: ${{ parameters.sonarOrganization }}
               sonarProjectKey: ${{ parameters.sonarProjectKey }}
-              sonarSources: ${{ parameters.projectName }}
+              sonarSources: '.'

--- a/V3/CI/Agnostic/quality-angular.yaml
+++ b/V3/CI/Agnostic/quality-angular.yaml
@@ -16,6 +16,22 @@ parameters:
   - name: checkoutRepository
     type: string
 
+  - name: enableSonar
+    type: boolean
+    default: false
+
+  - name: sonarServiceConnection
+    type: string
+    default: 'SonarCloud'
+
+  - name: sonarOrganization
+    type: string
+    default: ''
+
+  - name: sonarProjectKey
+    type: string
+    default: ''
+
 variables:
   - name: nodeVersion
     value: '22.x'
@@ -27,3 +43,10 @@ stages:
       checkoutRepository: ${{ parameters.checkoutRepository }}
       buildAndTestSteps:
         - template: ../Common/Steps/angular-quality.yaml
+        - ${{ if parameters.enableSonar }}:
+          - template: ../Common/Steps/angular-sonar.yaml
+            parameters:
+              sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+              sonarOrganization: ${{ parameters.sonarOrganization }}
+              sonarProjectKey: ${{ parameters.sonarProjectKey }}
+              sonarSources: ${{ parameters.projectName }}

--- a/V3/CI/Agnostic/quality-dotNet.yaml
+++ b/V3/CI/Agnostic/quality-dotNet.yaml
@@ -16,6 +16,22 @@ parameters:
   - name: checkoutRepository
     type: string
 
+  - name: enableSonar
+    type: boolean
+    default: false
+
+  - name: sonarServiceConnection
+    type: string
+    default: 'SonarCloud'
+
+  - name: sonarOrganization
+    type: string
+    default: ''
+
+  - name: sonarProjectKey
+    type: string
+    default: ''
+
 variables:
   - name: dotnetVersion
     value: '10.0.x'
@@ -37,3 +53,9 @@ stages:
           parameters:
             projects: '$(buildProjects)'
         - template: ../Common/Steps/dotnet-test.yaml
+        - ${{ if parameters.enableSonar }}:
+          - template: ../Common/Steps/dotnet-sonar.yaml
+            parameters:
+              sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+              sonarOrganization: ${{ parameters.sonarOrganization }}
+              sonarProjectKey: ${{ parameters.sonarProjectKey }}

--- a/V3/CI/Common/Steps/angular-sonar.yaml
+++ b/V3/CI/Common/Steps/angular-sonar.yaml
@@ -45,6 +45,29 @@ parameters:
 # ─────────────────────────────────────────────────────────────────────────────
 
 steps:
+  - script: |
+      set -euo pipefail
+
+      service_connection='${{ parameters.sonarServiceConnection }}'
+      organization='${{ parameters.sonarOrganization }}'
+      project_key='${{ parameters.sonarProjectKey }}'
+
+      if [[ -z "${service_connection// }" ]]; then
+        echo "ERROR: 'sonarServiceConnection' is required when SonarCloud analysis is enabled."
+        exit 1
+      fi
+
+      if [[ -z "${organization// }" ]]; then
+        echo "ERROR: 'sonarOrganization' is required when SonarCloud analysis is enabled."
+        exit 1
+      fi
+
+      if [[ -z "${project_key// }" ]]; then
+        echo "ERROR: 'sonarProjectKey' is required when SonarCloud analysis is enabled."
+        exit 1
+      fi
+    displayName: 'Validate SonarCloud required parameters'
+
   - task: SonarCloudPrepare@2
     displayName: 'SonarCloud Prepare'
     inputs:

--- a/V3/CI/Common/Steps/angular-sonar.yaml
+++ b/V3/CI/Common/Steps/angular-sonar.yaml
@@ -1,0 +1,66 @@
+# ── CI Step: SonarCloud — Angular ──────────────────────────────────────────────
+#
+# Esegue l'analisi SonarCloud completa (Prepare → Analyze → Publish) per
+# progetti Angular in CLI mode. Da iniettare dopo angular-quality.yaml.
+#
+# Riusato da:
+#   CI/GitFlow/quality-angular.yaml
+#   CI/Agnostic/quality-angular.yaml
+#
+# Parametri
+# ─────────
+#   sonarServiceConnection → nome della Service Connection ADO di tipo SonarCloud [REQUIRED]
+#   sonarOrganization      → nome organizzazione SonarCloud                       [REQUIRED]
+#   sonarProjectKey        → chiave univoca del progetto SonarCloud               [REQUIRED]
+#   sonarSources           → cartella sorgenti (es. nome del progetto Angular)    [REQUIRED]
+#   sonarProjectName       → nome del progetto (default: sonarProjectKey)
+#   sonarExtraProperties   → proprietà aggiuntive (es. coverage report path)
+#
+# Coverage Angular:
+#   sonarExtraProperties: 'sonar.javascript.lcov.reportPaths=$(projectName)/coverage/lcov.info'
+#
+# ─────────────────────────────────────────────────────────────────────────────
+
+parameters:
+  - name: sonarServiceConnection
+    type: string
+
+  - name: sonarOrganization
+    type: string
+
+  - name: sonarProjectKey
+    type: string
+
+  - name: sonarSources
+    type: string
+
+  - name: sonarProjectName
+    type: string
+    default: '${{ parameters.sonarProjectKey }}'
+
+  - name: sonarExtraProperties
+    type: string
+    default: ''
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+steps:
+  - task: SonarCloudPrepare@2
+    displayName: 'SonarCloud Prepare'
+    inputs:
+      SonarCloud: '${{ parameters.sonarServiceConnection }}'
+      organization: '${{ parameters.sonarOrganization }}'
+      scannerMode: 'CLI'
+      configMode: 'manual'
+      cliProjectKey: '${{ parameters.sonarProjectKey }}'
+      cliProjectName: '${{ parameters.sonarProjectName }}'
+      cliSources: '${{ parameters.sonarSources }}'
+      extraProperties: '${{ parameters.sonarExtraProperties }}'
+
+  - task: SonarCloudAnalyze@2
+    displayName: 'SonarCloud Analyze'
+
+  - task: SonarCloudPublish@2
+    displayName: 'SonarCloud Publish'
+    inputs:
+      pollingTimeoutSec: '300'

--- a/V3/CI/Common/Steps/angular-sonar.yaml
+++ b/V3/CI/Common/Steps/angular-sonar.yaml
@@ -17,7 +17,7 @@
 #   sonarExtraProperties   → proprietà aggiuntive (es. coverage report path)
 #
 # Coverage Angular:
-#   sonarExtraProperties: 'sonar.javascript.lcov.reportPaths=$(projectName)/coverage/lcov.info'
+#   sonarExtraProperties: 'sonar.javascript.lcov.reportPaths=${{ parameters.sonarSources }}/coverage/lcov.info'
 #
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/V3/CI/Common/Steps/dotnet-sonar.yaml
+++ b/V3/CI/Common/Steps/dotnet-sonar.yaml
@@ -48,6 +48,29 @@ parameters:
 # ─────────────────────────────────────────────────────────────────────────────
 
 steps:
+  - script: |
+      set -euo pipefail
+
+      service_connection='${{ parameters.sonarServiceConnection }}'
+      organization='${{ parameters.sonarOrganization }}'
+      project_key='${{ parameters.sonarProjectKey }}'
+
+      if [[ -z "${service_connection// }" ]]; then
+        echo "ERROR: 'sonarServiceConnection' is required when SonarCloud analysis is enabled."
+        exit 1
+      fi
+
+      if [[ -z "${organization// }" ]]; then
+        echo "ERROR: 'sonarOrganization' is required when SonarCloud analysis is enabled."
+        exit 1
+      fi
+
+      if [[ -z "${project_key// }" ]]; then
+        echo "ERROR: 'sonarProjectKey' is required when SonarCloud analysis is enabled."
+        exit 1
+      fi
+    displayName: 'Validate SonarCloud required parameters'
+
   - task: SonarCloudPrepare@2
     displayName: 'SonarCloud Prepare'
     inputs:

--- a/V3/CI/Common/Steps/dotnet-sonar.yaml
+++ b/V3/CI/Common/Steps/dotnet-sonar.yaml
@@ -1,0 +1,67 @@
+# ── CI Step: SonarCloud — .NET ─────────────────────────────────────────────────
+#
+# Esegue l'analisi SonarCloud completa (Prepare → Analyze → Publish) per
+# progetti .NET in CLI mode. Da iniettare dopo dotnet-test.yaml.
+#
+# Riusato da:
+#   CI/GitFlow/quality-dotNet.yaml
+#   CI/Agnostic/quality-dotNet.yaml
+#
+# Parametri
+# ─────────
+#   sonarServiceConnection → nome della Service Connection ADO di tipo SonarCloud [REQUIRED]
+#   sonarOrganization      → nome organizzazione SonarCloud                       [REQUIRED]
+#   sonarProjectKey        → chiave univoca del progetto SonarCloud               [REQUIRED]
+#   sonarProjectName       → nome del progetto (default: sonarProjectKey)
+#   sonarSources           → cartella sorgenti da analizzare (default: '.')
+#   sonarExtraProperties   → proprietà aggiuntive (es. coverage report path)
+#
+# Coverage .NET:
+#   sonarExtraProperties: 'sonar.cs.opencover.reportsPaths=$(Agent.TempDirectory)/**/coverage.opencover.xml'
+#
+# ─────────────────────────────────────────────────────────────────────────────
+
+parameters:
+  - name: sonarServiceConnection
+    type: string
+
+  - name: sonarOrganization
+    type: string
+
+  - name: sonarProjectKey
+    type: string
+
+  - name: sonarProjectName
+    type: string
+    default: '${{ parameters.sonarProjectKey }}'
+
+  - name: sonarSources
+    type: string
+    default: '.'
+
+  - name: sonarExtraProperties
+    type: string
+    default: ''
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+steps:
+  - task: SonarCloudPrepare@2
+    displayName: 'SonarCloud Prepare'
+    inputs:
+      SonarCloud: '${{ parameters.sonarServiceConnection }}'
+      organization: '${{ parameters.sonarOrganization }}'
+      scannerMode: 'CLI'
+      configMode: 'manual'
+      cliProjectKey: '${{ parameters.sonarProjectKey }}'
+      cliProjectName: '${{ parameters.sonarProjectName }}'
+      cliSources: '${{ parameters.sonarSources }}'
+      extraProperties: '${{ parameters.sonarExtraProperties }}'
+
+  - task: SonarCloudAnalyze@2
+    displayName: 'SonarCloud Analyze'
+
+  - task: SonarCloudPublish@2
+    displayName: 'SonarCloud Publish'
+    inputs:
+      pollingTimeoutSec: '300'

--- a/V3/CI/Common/Steps/dotnet-sonar.yaml
+++ b/V3/CI/Common/Steps/dotnet-sonar.yaml
@@ -17,7 +17,9 @@
 #   sonarExtraProperties   → proprietà aggiuntive (es. coverage report path)
 #
 # Coverage .NET:
-#   sonarExtraProperties: 'sonar.cs.opencover.reportsPaths=$(Agent.TempDirectory)/**/coverage.opencover.xml'
+#   impostare sonarExtraProperties in base al formato di report effettivamente
+#   prodotto da dotnet-test.yaml (es. Cobertura), evitando riferimenti a file
+#   OpenCover come coverage.opencover.xml se non vengono generati.
 #
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/V3/CI/GitFlow/quality-angular.yaml
+++ b/V3/CI/GitFlow/quality-angular.yaml
@@ -49,4 +49,4 @@ stages:
               sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
               sonarOrganization: ${{ parameters.sonarOrganization }}
               sonarProjectKey: ${{ parameters.sonarProjectKey }}
-              sonarSources: ${{ parameters.projectName }}
+              sonarSources: '.'

--- a/V3/CI/GitFlow/quality-angular.yaml
+++ b/V3/CI/GitFlow/quality-angular.yaml
@@ -15,6 +15,22 @@ parameters:
   - name: checkoutRepository
     type: string
 
+  - name: enableSonar
+    type: boolean
+    default: false
+
+  - name: sonarServiceConnection
+    type: string
+    default: 'SonarCloud'
+
+  - name: sonarOrganization
+    type: string
+    default: ''
+
+  - name: sonarProjectKey
+    type: string
+    default: ''
+
 variables:
   - name: nodeVersion
     value: '22.x'
@@ -27,3 +43,10 @@ stages:
       checkoutRepository: ${{ parameters.checkoutRepository }}
       buildAndTestSteps:
         - template: ../Common/Steps/angular-quality.yaml
+        - ${{ if parameters.enableSonar }}:
+          - template: ../Common/Steps/angular-sonar.yaml
+            parameters:
+              sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+              sonarOrganization: ${{ parameters.sonarOrganization }}
+              sonarProjectKey: ${{ parameters.sonarProjectKey }}
+              sonarSources: ${{ parameters.projectName }}

--- a/V3/CI/GitFlow/quality-dotNet.yaml
+++ b/V3/CI/GitFlow/quality-dotNet.yaml
@@ -19,6 +19,22 @@ parameters:
     type: boolean
     default: true
 
+  - name: enableSonar
+    type: boolean
+    default: false
+
+  - name: sonarServiceConnection
+    type: string
+    default: 'SonarCloud'
+
+  - name: sonarOrganization
+    type: string
+    default: ''
+
+  - name: sonarProjectKey
+    type: string
+    default: ''
+
 variables:
   - name: dotnetVersion
     value: '10.0.x'
@@ -42,3 +58,9 @@ stages:
           parameters:
             projects: '$(buildProjects)'
         - template: ../Common/Steps/dotnet-test.yaml
+        - ${{ if parameters.enableSonar }}:
+          - template: ../Common/Steps/dotnet-sonar.yaml
+            parameters:
+              sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+              sonarOrganization: ${{ parameters.sonarOrganization }}
+              sonarProjectKey: ${{ parameters.sonarProjectKey }}

--- a/V3/CLAUDE.md
+++ b/V3/CLAUDE.md
@@ -230,3 +230,6 @@ Queste variabili devono essere definite nell'entry point (come `variables:` o tr
 | `appLocation` | stringa | `staticWebApp-deploy.yaml` |
 | `currentTag` | stringa | `versionArgs` (esposto da Set-Versioning) |
 | `gitHash` | stringa | `versionArgs` (esposto da Set-Versioning) |
+| `sonarServiceConnection` | **parametro entry point** | quality-dotNet.yaml, quality-angular.yaml → `dotnet-sonar.yaml`, `angular-sonar.yaml` |
+| `sonarOrganization` | **parametro entry point** | quality-dotNet.yaml, quality-angular.yaml → `dotnet-sonar.yaml`, `angular-sonar.yaml` |
+| `sonarProjectKey` | **parametro entry point** | quality-dotNet.yaml, quality-angular.yaml → `dotnet-sonar.yaml`, `angular-sonar.yaml` |


### PR DESCRIPTION
Add dotnet-sonar.yaml and angular-sonar.yaml step templates (CLI mode, Prepare+Analyze+Publish in one file). Enable via enableSonar: true on quality-dotNet and quality-angular entry points (Agnostic and GitFlow).