### PR TITLE
fix: move enableSonar flag into step templates to avoid invalid templ…

### DIFF
--- a/V3/CI/Agnostic/quality-angular.yaml
+++ b/V3/CI/Agnostic/quality-angular.yaml
@@ -43,10 +43,9 @@ stages:
       checkoutRepository: ${{ parameters.checkoutRepository }}
       buildAndTestSteps:
         - template: ../Common/Steps/angular-quality.yaml
-        - ${{ if parameters.enableSonar }}:
-          - template: ../Common/Steps/angular-sonar.yaml
-            parameters:
-              sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
-              sonarOrganization: ${{ parameters.sonarOrganization }}
-              sonarProjectKey: ${{ parameters.sonarProjectKey }}
-              sonarSources: '.'
+        - template: ../Common/Steps/angular-sonar.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}

--- a/V3/CI/Agnostic/quality-dotNet.yaml
+++ b/V3/CI/Agnostic/quality-dotNet.yaml
@@ -53,9 +53,9 @@ stages:
           parameters:
             projects: '$(buildProjects)'
         - template: ../Common/Steps/dotnet-test.yaml
-        - ${{ if parameters.enableSonar }}:
-          - template: ../Common/Steps/dotnet-sonar.yaml
-            parameters:
-              sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
-              sonarOrganization: ${{ parameters.sonarOrganization }}
-              sonarProjectKey: ${{ parameters.sonarProjectKey }}
+        - template: ../Common/Steps/dotnet-sonar.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}

--- a/V3/CI/Common/Steps/angular-sonar.yaml
+++ b/V3/CI/Common/Steps/angular-sonar.yaml
@@ -2,6 +2,7 @@
 #
 # Esegue l'analisi SonarCloud completa (Prepare → Analyze → Publish) per
 # progetti Angular in CLI mode. Da iniettare dopo angular-quality.yaml.
+# Quando enableSonar è false tutti gli step vengono saltati.
 #
 # Riusato da:
 #   CI/GitFlow/quality-angular.yaml
@@ -9,34 +10,38 @@
 #
 # Parametri
 # ─────────
-#   sonarServiceConnection → nome della Service Connection ADO di tipo SonarCloud [REQUIRED]
-#   sonarOrganization      → nome organizzazione SonarCloud                       [REQUIRED]
-#   sonarProjectKey        → chiave univoca del progetto SonarCloud               [REQUIRED]
-#   sonarSources           → cartella sorgenti (es. nome del progetto Angular)    [REQUIRED]
-#   sonarProjectName       → nome del progetto (default: sonarProjectKey)
+#   enableSonar            → abilita l'analisi (default: false)
+#   sonarServiceConnection → nome della Service Connection ADO di tipo SonarCloud
+#   sonarOrganization      → nome organizzazione SonarCloud
+#   sonarProjectKey        → chiave univoca del progetto SonarCloud
+#   sonarSources           → cartella sorgenti (es. nome del progetto Angular)
 #   sonarExtraProperties   → proprietà aggiuntive (es. coverage report path)
 #
 # Coverage Angular:
-#   sonarExtraProperties: 'sonar.javascript.lcov.reportPaths=${{ parameters.sonarSources }}/coverage/lcov.info'
+#   sonarExtraProperties: 'sonar.javascript.lcov.reportPaths=<projectName>/coverage/lcov.info'
 #
 # ─────────────────────────────────────────────────────────────────────────────
 
 parameters:
+  - name: enableSonar
+    type: boolean
+    default: false
+
   - name: sonarServiceConnection
     type: string
+    default: ''
 
   - name: sonarOrganization
     type: string
+    default: ''
 
   - name: sonarProjectKey
     type: string
+    default: ''
 
   - name: sonarSources
     type: string
-
-  - name: sonarProjectName
-    type: string
-    default: '${{ parameters.sonarProjectKey }}'
+    default: '.'
 
   - name: sonarExtraProperties
     type: string
@@ -45,45 +50,46 @@ parameters:
 # ─────────────────────────────────────────────────────────────────────────────
 
 steps:
-  - script: |
-      set -euo pipefail
+  - ${{ if parameters.enableSonar }}:
+    - script: |
+        set -euo pipefail
 
-      service_connection='${{ parameters.sonarServiceConnection }}'
-      organization='${{ parameters.sonarOrganization }}'
-      project_key='${{ parameters.sonarProjectKey }}'
+        service_connection='${{ parameters.sonarServiceConnection }}'
+        organization='${{ parameters.sonarOrganization }}'
+        project_key='${{ parameters.sonarProjectKey }}'
 
-      if [[ -z "${service_connection// }" ]]; then
-        echo "ERROR: 'sonarServiceConnection' is required when SonarCloud analysis is enabled."
-        exit 1
-      fi
+        if [[ -z "${service_connection// }" ]]; then
+          echo "ERROR: 'sonarServiceConnection' is required when SonarCloud analysis is enabled."
+          exit 1
+        fi
 
-      if [[ -z "${organization// }" ]]; then
-        echo "ERROR: 'sonarOrganization' is required when SonarCloud analysis is enabled."
-        exit 1
-      fi
+        if [[ -z "${organization// }" ]]; then
+          echo "ERROR: 'sonarOrganization' is required when SonarCloud analysis is enabled."
+          exit 1
+        fi
 
-      if [[ -z "${project_key// }" ]]; then
-        echo "ERROR: 'sonarProjectKey' is required when SonarCloud analysis is enabled."
-        exit 1
-      fi
-    displayName: 'Validate SonarCloud required parameters'
+        if [[ -z "${project_key// }" ]]; then
+          echo "ERROR: 'sonarProjectKey' is required when SonarCloud analysis is enabled."
+          exit 1
+        fi
+      displayName: 'Validate SonarCloud required parameters'
 
-  - task: SonarCloudPrepare@2
-    displayName: 'SonarCloud Prepare'
-    inputs:
-      SonarCloud: '${{ parameters.sonarServiceConnection }}'
-      organization: '${{ parameters.sonarOrganization }}'
-      scannerMode: 'CLI'
-      configMode: 'manual'
-      cliProjectKey: '${{ parameters.sonarProjectKey }}'
-      cliProjectName: '${{ parameters.sonarProjectName }}'
-      cliSources: '${{ parameters.sonarSources }}'
-      extraProperties: '${{ parameters.sonarExtraProperties }}'
+    - task: SonarCloudPrepare@2
+      displayName: 'SonarCloud Prepare'
+      inputs:
+        SonarCloud: '${{ parameters.sonarServiceConnection }}'
+        organization: '${{ parameters.sonarOrganization }}'
+        scannerMode: 'CLI'
+        configMode: 'manual'
+        cliProjectKey: '${{ parameters.sonarProjectKey }}'
+        cliProjectName: '${{ parameters.sonarProjectKey }}'
+        cliSources: '${{ parameters.sonarSources }}'
+        extraProperties: '${{ parameters.sonarExtraProperties }}'
 
-  - task: SonarCloudAnalyze@2
-    displayName: 'SonarCloud Analyze'
+    - task: SonarCloudAnalyze@2
+      displayName: 'SonarCloud Analyze'
 
-  - task: SonarCloudPublish@2
-    displayName: 'SonarCloud Publish'
-    inputs:
-      pollingTimeoutSec: '300'
+    - task: SonarCloudPublish@2
+      displayName: 'SonarCloud Publish'
+      inputs:
+        pollingTimeoutSec: '300'

--- a/V3/CI/Common/Steps/dotnet-sonar.yaml
+++ b/V3/CI/Common/Steps/dotnet-sonar.yaml
@@ -2,6 +2,7 @@
 #
 # Esegue l'analisi SonarCloud completa (Prepare → Analyze → Publish) per
 # progetti .NET in CLI mode. Da iniettare dopo dotnet-test.yaml.
+# Quando enableSonar è false tutti gli step vengono saltati.
 #
 # Riusato da:
 #   CI/GitFlow/quality-dotNet.yaml
@@ -9,33 +10,34 @@
 #
 # Parametri
 # ─────────
-#   sonarServiceConnection → nome della Service Connection ADO di tipo SonarCloud [REQUIRED]
-#   sonarOrganization      → nome organizzazione SonarCloud                       [REQUIRED]
-#   sonarProjectKey        → chiave univoca del progetto SonarCloud               [REQUIRED]
-#   sonarProjectName       → nome del progetto (default: sonarProjectKey)
+#   enableSonar            → abilita l'analisi (default: false)
+#   sonarServiceConnection → nome della Service Connection ADO di tipo SonarCloud
+#   sonarOrganization      → nome organizzazione SonarCloud
+#   sonarProjectKey        → chiave univoca del progetto SonarCloud
 #   sonarSources           → cartella sorgenti da analizzare (default: '.')
 #   sonarExtraProperties   → proprietà aggiuntive (es. coverage report path)
 #
 # Coverage .NET:
-#   impostare sonarExtraProperties in base al formato di report effettivamente
-#   prodotto da dotnet-test.yaml (es. Cobertura), evitando riferimenti a file
-#   OpenCover come coverage.opencover.xml se non vengono generati.
+#   sonarExtraProperties: 'sonar.cs.opencover.reportsPaths=$(Agent.TempDirectory)/**/coverage.opencover.xml'
 #
 # ─────────────────────────────────────────────────────────────────────────────
 
 parameters:
+  - name: enableSonar
+    type: boolean
+    default: false
+
   - name: sonarServiceConnection
     type: string
+    default: ''
 
   - name: sonarOrganization
     type: string
+    default: ''
 
   - name: sonarProjectKey
     type: string
-
-  - name: sonarProjectName
-    type: string
-    default: '${{ parameters.sonarProjectKey }}'
+    default: ''
 
   - name: sonarSources
     type: string
@@ -48,45 +50,46 @@ parameters:
 # ─────────────────────────────────────────────────────────────────────────────
 
 steps:
-  - script: |
-      set -euo pipefail
+  - ${{ if parameters.enableSonar }}:
+    - script: |
+        set -euo pipefail
 
-      service_connection='${{ parameters.sonarServiceConnection }}'
-      organization='${{ parameters.sonarOrganization }}'
-      project_key='${{ parameters.sonarProjectKey }}'
+        service_connection='${{ parameters.sonarServiceConnection }}'
+        organization='${{ parameters.sonarOrganization }}'
+        project_key='${{ parameters.sonarProjectKey }}'
 
-      if [[ -z "${service_connection// }" ]]; then
-        echo "ERROR: 'sonarServiceConnection' is required when SonarCloud analysis is enabled."
-        exit 1
-      fi
+        if [[ -z "${service_connection// }" ]]; then
+          echo "ERROR: 'sonarServiceConnection' is required when SonarCloud analysis is enabled."
+          exit 1
+        fi
 
-      if [[ -z "${organization// }" ]]; then
-        echo "ERROR: 'sonarOrganization' is required when SonarCloud analysis is enabled."
-        exit 1
-      fi
+        if [[ -z "${organization// }" ]]; then
+          echo "ERROR: 'sonarOrganization' is required when SonarCloud analysis is enabled."
+          exit 1
+        fi
 
-      if [[ -z "${project_key// }" ]]; then
-        echo "ERROR: 'sonarProjectKey' is required when SonarCloud analysis is enabled."
-        exit 1
-      fi
-    displayName: 'Validate SonarCloud required parameters'
+        if [[ -z "${project_key// }" ]]; then
+          echo "ERROR: 'sonarProjectKey' is required when SonarCloud analysis is enabled."
+          exit 1
+        fi
+      displayName: 'Validate SonarCloud required parameters'
 
-  - task: SonarCloudPrepare@2
-    displayName: 'SonarCloud Prepare'
-    inputs:
-      SonarCloud: '${{ parameters.sonarServiceConnection }}'
-      organization: '${{ parameters.sonarOrganization }}'
-      scannerMode: 'CLI'
-      configMode: 'manual'
-      cliProjectKey: '${{ parameters.sonarProjectKey }}'
-      cliProjectName: '${{ parameters.sonarProjectName }}'
-      cliSources: '${{ parameters.sonarSources }}'
-      extraProperties: '${{ parameters.sonarExtraProperties }}'
+    - task: SonarCloudPrepare@2
+      displayName: 'SonarCloud Prepare'
+      inputs:
+        SonarCloud: '${{ parameters.sonarServiceConnection }}'
+        organization: '${{ parameters.sonarOrganization }}'
+        scannerMode: 'CLI'
+        configMode: 'manual'
+        cliProjectKey: '${{ parameters.sonarProjectKey }}'
+        cliProjectName: '${{ parameters.sonarProjectKey }}'
+        cliSources: '${{ parameters.sonarSources }}'
+        extraProperties: '${{ parameters.sonarExtraProperties }}'
 
-  - task: SonarCloudAnalyze@2
-    displayName: 'SonarCloud Analyze'
+    - task: SonarCloudAnalyze@2
+      displayName: 'SonarCloud Analyze'
 
-  - task: SonarCloudPublish@2
-    displayName: 'SonarCloud Publish'
-    inputs:
-      pollingTimeoutSec: '300'
+    - task: SonarCloudPublish@2
+      displayName: 'SonarCloud Publish'
+      inputs:
+        pollingTimeoutSec: '300'

--- a/V3/CI/Common/Steps/dotnet-sonar.yaml
+++ b/V3/CI/Common/Steps/dotnet-sonar.yaml
@@ -18,7 +18,7 @@
 #   sonarExtraProperties   → proprietà aggiuntive (es. coverage report path)
 #
 # Coverage .NET:
-#   sonarExtraProperties: 'sonar.cs.opencover.reportsPaths=$(Agent.TempDirectory)/**/coverage.opencover.xml'
+#   sonarExtraProperties: 'sonar.cs.cobertura.reportsPaths=$(Agent.TempDirectory)/**/coverage.cobertura.xml'
 #
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/V3/CI/GitFlow/quality-angular.yaml
+++ b/V3/CI/GitFlow/quality-angular.yaml
@@ -43,10 +43,9 @@ stages:
       checkoutRepository: ${{ parameters.checkoutRepository }}
       buildAndTestSteps:
         - template: ../Common/Steps/angular-quality.yaml
-        - ${{ if parameters.enableSonar }}:
-          - template: ../Common/Steps/angular-sonar.yaml
-            parameters:
-              sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
-              sonarOrganization: ${{ parameters.sonarOrganization }}
-              sonarProjectKey: ${{ parameters.sonarProjectKey }}
-              sonarSources: '.'
+        - template: ../Common/Steps/angular-sonar.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}

--- a/V3/CI/GitFlow/quality-dotNet.yaml
+++ b/V3/CI/GitFlow/quality-dotNet.yaml
@@ -58,9 +58,9 @@ stages:
           parameters:
             projects: '$(buildProjects)'
         - template: ../Common/Steps/dotnet-test.yaml
-        - ${{ if parameters.enableSonar }}:
-          - template: ../Common/Steps/dotnet-sonar.yaml
-            parameters:
-              sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
-              sonarOrganization: ${{ parameters.sonarOrganization }}
-              sonarProjectKey: ${{ parameters.sonarProjectKey }}
+        - template: ../Common/Steps/dotnet-sonar.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}


### PR DESCRIPTION
…ate expression in default and conditional in stepList parameter

Remove sonarProjectName (default used ${{ }} in parameter default — not allowed in ADO YAML). Move ${{ if enableSonar }} inside the step template steps block (supported context) instead of the entry-point stepList (unsupported context that caused NullReferenceException).