### PR TITLE
feat: add optional SonarCloud analysis to quality pipelines

### DIFF
--- a/V3/CI/Common/Steps/angular-sonar.yaml
+++ b/V3/CI/Common/Steps/angular-sonar.yaml
@@ -92,4 +92,5 @@ steps:
     - task: SonarCloudPublish@3
       displayName: 'SonarCloud Publish'
       inputs:
+        SonarCloud: '${{ parameters.sonarServiceConnection }}'
         pollingTimeoutSec: '300'

--- a/V3/CI/Common/Steps/dotnet-sonar.yaml
+++ b/V3/CI/Common/Steps/dotnet-sonar.yaml
@@ -92,4 +92,5 @@ steps:
     - task: SonarCloudPublish@3
       displayName: 'SonarCloud Publish'
       inputs:
+        SonarCloud: '${{ parameters.sonarServiceConnection }}'
         pollingTimeoutSec: '300'


### PR DESCRIPTION
## Summary

- Add `dotnet-sonar.yaml` and `angular-sonar.yaml` step templates with full SonarCloud analysis (Prepare → Analyze → Publish) using CLI mode
- Add `enableSonar: boolean` flag to all quality entry points (GitFlow + Agnostic, .NET + Angular) — default `false`, zero impact on existing pipelines
- Sonar parameters (`sonarServiceConnection`, `sonarOrganization`, `sonarProjectKey`) passed explicitly from entry point to step template
- `${{ if enableSonar }}` lives inside the step template `steps:` block (supported ADO context) — not in the stepList parameter (unsupported)
- Use `SonarCloudPrepare/Analyze/Publish@3`; service connection passed explicitly to Publish task

## Test plan

- [x] Pipeline with `enableSonar: false` → no SonarCloud steps appear
- [x] Pipeline with `enableSonar: true` + valid `sonarOrganization` + `sonarProjectKey` → analysis appears in SonarCloud dashboard
- [x] Static analysis: `yamllint`, `check-references.py`, `check-parameters.py` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)