### PR TITLE
feat: add SonarCloud analysis to CI publish pipelines

### DIFF
--- a/V3/CI/Agnostic/publish-angular.yaml
+++ b/V3/CI/Agnostic/publish-angular.yaml
@@ -30,6 +30,22 @@ parameters:
     type: string
     default: 'development'
 
+  - name: enableSonar
+    type: boolean
+    default: false
+
+  - name: sonarServiceConnection
+    type: string
+    default: 'SonarCloud'
+
+  - name: sonarOrganization
+    type: string
+    default: ''
+
+  - name: sonarProjectKey
+    type: string
+    default: ''
+
 variables:
   - name: nodeVersion
     value: '22.x'
@@ -48,6 +64,12 @@ stages:
         - template: ../Common/Steps/angular-build.yaml
           parameters:
             buildConfiguration: '${{ parameters.buildConfiguration }}'
+        - template: ../Common/Steps/angular-sonar.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}
 
       publishSteps:
         - template: ../Common/Steps/angular-publish.yaml

--- a/V3/CI/Agnostic/publish-dotNet.yaml
+++ b/V3/CI/Agnostic/publish-dotNet.yaml
@@ -45,6 +45,22 @@ parameters:
     # Obbligatorio se variableSubstitution: true
     # Esempio: 'MyApp/MyApp' (path relativo a $(Build.SourcesDirectory))
 
+  - name: enableSonar
+    type: boolean
+    default: false
+
+  - name: sonarServiceConnection
+    type: string
+    default: 'SonarCloud'
+
+  - name: sonarOrganization
+    type: string
+    default: ''
+
+  - name: sonarProjectKey
+    type: string
+    default: ''
+
 stages:
   - template: ../Common/publish.yaml
     parameters:
@@ -57,6 +73,12 @@ stages:
             projects: '${{ parameters.projectName }}/${{ parameters.projectName }}.csproj'
             dotnetVersion: '10.0.x'
             buildConfiguration: 'Release'
+        - template: ../Common/Steps/dotnet-sonar.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}
 
       publishSteps:
         - template: ../Common/Steps/dotnet-publish.yaml

--- a/V3/CI/GitFlow/publish-angular.yaml
+++ b/V3/CI/GitFlow/publish-angular.yaml
@@ -16,6 +16,22 @@ parameters:
   - name: checkoutRepository
     type: string
 
+  - name: enableSonar
+    type: boolean
+    default: false
+
+  - name: sonarServiceConnection
+    type: string
+    default: 'SonarCloud'
+
+  - name: sonarOrganization
+    type: string
+    default: ''
+
+  - name: sonarProjectKey
+    type: string
+    default: ''
+
 variables:
   - name: nodeVersion
     value: '22.x'
@@ -59,6 +75,12 @@ stages:
       checkoutRepository: ${{ parameters.checkoutRepository }}
       buildSteps:
         - template: ../Common/Steps/angular-build.yaml
+        - template: ../Common/Steps/angular-sonar.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}
 
       publishSteps:
         - template: ../Common/Steps/angular-publish.yaml

--- a/V3/CI/GitFlow/publish-dotNet.yaml
+++ b/V3/CI/GitFlow/publish-dotNet.yaml
@@ -37,6 +37,22 @@ parameters:
     # Obbligatorio se variableSubstitution: true
     # Esempio: 'MyApp/MyApp' (path relativo a $(Build.SourcesDirectory))
 
+  - name: enableSonar
+    type: boolean
+    default: false
+
+  - name: sonarServiceConnection
+    type: string
+    default: 'SonarCloud'
+
+  - name: sonarOrganization
+    type: string
+    default: ''
+
+  - name: sonarProjectKey
+    type: string
+    default: ''
+
 variables:
   - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/dev') }}:
     - group: "development"
@@ -71,6 +87,12 @@ stages:
             projects: '**/${{ parameters.projectName }}.csproj'
             dotnetVersion: '10.0.x'
             buildConfiguration: 'Release'
+        - template: ../Common/Steps/dotnet-sonar.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}
 
       publishSteps:
         - template: ../Common/Steps/dotnet-publish.yaml

--- a/V3/CI/TrunkFlow/publish-dotNet.yaml
+++ b/V3/CI/TrunkFlow/publish-dotNet.yaml
@@ -50,6 +50,22 @@ parameters:
     # Obbligatorio se variableSubstitution: true
     # Esempio: 'MyApp/MyApp' (path relativo a $(Build.SourcesDirectory))
 
+  - name: enableSonar
+    type: boolean
+    default: false
+
+  - name: sonarServiceConnection
+    type: string
+    default: 'SonarCloud'
+
+  - name: sonarOrganization
+    type: string
+    default: ''
+
+  - name: sonarProjectKey
+    type: string
+    default: ''
+
 variables:
   - name: targetEnvironment
     value: 'Development'
@@ -66,6 +82,12 @@ stages:
             projects: '${{ parameters.projectName }}/${{ parameters.projectName }}.csproj'
             dotnetVersion: '10.0.x'
             buildConfiguration: 'Release'
+        - template: ../Common/Steps/dotnet-sonar.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}
 
       publishSteps:
         - template: ../Common/Steps/dotnet-publish.yaml


### PR DESCRIPTION
## Summary

- Add `enableSonar`, `sonarServiceConnection`, `sonarOrganization`, `sonarProjectKey` parameters to all 5 CI publish entry points (Agnostic, GitFlow, TrunkFlow for .NET; Agnostic, GitFlow for Angular)
- Inject existing `dotnet-sonar.yaml` / `angular-sonar.yaml` step templates into `buildSteps` after the build step
- Reuses the same step templates already used by quality pipelines — no new files created
- `enableSonar` defaults to `false` → zero breaking change for existing consumers
- SonarCloud runs on long-lived branches (main/dev/staging) post-merge where the free plan quality gate API is available

## Test plan

- [ ] Existing publish pipeline with no sonar params → unchanged behavior
- [ ] Publish pipeline with `enableSonar: true` on main → SonarCloud Prepare + Analyze + Publish in ADO log
- [ ] Publish pipeline with `enableSonar: false` → sonar steps skipped entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)