### PR TITLE
fix: add continueOnError to SonarCloudPublish to prevent pipeline failure

### DIFF
--- a/V3/CI/Common/Steps/angular-sonar.yaml
+++ b/V3/CI/Common/Steps/angular-sonar.yaml
@@ -91,6 +91,7 @@ steps:
 
     - task: SonarCloudPublish@3
       displayName: 'SonarCloud Publish'
+      continueOnError: true
       inputs:
         SonarCloud: '${{ parameters.sonarServiceConnection }}'
         pollingTimeoutSec: '300'

--- a/V3/CI/Common/Steps/dotnet-sonar.yaml
+++ b/V3/CI/Common/Steps/dotnet-sonar.yaml
@@ -91,6 +91,7 @@ steps:
 
     - task: SonarCloudPublish@3
       displayName: 'SonarCloud Publish'
+      continueOnError: true
       inputs:
         SonarCloud: '${{ parameters.sonarServiceConnection }}'
         pollingTimeoutSec: '300'


### PR DESCRIPTION
## Summary

- Add `continueOnError: true` to `SonarCloudPublish@3` in `dotnet-sonar.yaml` and `angular-sonar.yaml`
- Prevents pipeline failure when quality gate API returns errors (e.g. 403 on short-lived branches with free SonarCloud plan, network issues)
- Analysis and upload to SonarCloud dashboard still proceed normally

## Test plan

- [ ] Pipeline with `enableSonar: true` on feature branch → SonarCloudPublish fails gracefully, pipeline continues green
- [ ] Pipeline with `enableSonar: true` on main → SonarCloudPublish succeeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)