### PR TITLE
refactor: migrate SonarCloud .NET scanner from CLI to MSBuild mode

### DIFF
--- a/V3/CI/Agnostic/publish-dotNet.yaml
+++ b/V3/CI/Agnostic/publish-dotNet.yaml
@@ -68,6 +68,12 @@ stages:
       checkoutRepository: ${{ parameters.checkoutRepository }}
       artifactName: '${{ parameters.projectName }}-${{ parameters.targetEnvironment }}'
       buildSteps:
+        - template: ../Common/Steps/dotnet-sonar-prepare.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}
         - template: ../Common/Steps/dotnet-build.yaml
           parameters:
             projects: '${{ parameters.projectName }}/${{ parameters.projectName }}.csproj'
@@ -77,8 +83,6 @@ stages:
           parameters:
             enableSonar: ${{ parameters.enableSonar }}
             sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
-            sonarOrganization: ${{ parameters.sonarOrganization }}
-            sonarProjectKey: ${{ parameters.sonarProjectKey }}
 
       publishSteps:
         - template: ../Common/Steps/dotnet-publish.yaml

--- a/V3/CI/Agnostic/quality-dotNet.yaml
+++ b/V3/CI/Agnostic/quality-dotNet.yaml
@@ -49,6 +49,12 @@ stages:
       checkoutRepository: ${{ parameters.checkoutRepository }}
       buildAndTestSteps:
         - template: ../Common/Steps/dotnet-nuget-check.yaml
+        - template: ../Common/Steps/dotnet-sonar-prepare.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}
         - template: ../Common/Steps/dotnet-build.yaml
           parameters:
             projects: '$(buildProjects)'
@@ -57,5 +63,3 @@ stages:
           parameters:
             enableSonar: ${{ parameters.enableSonar }}
             sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
-            sonarOrganization: ${{ parameters.sonarOrganization }}
-            sonarProjectKey: ${{ parameters.sonarProjectKey }}

--- a/V3/CI/Common/Steps/dotnet-sonar-prepare.yaml
+++ b/V3/CI/Common/Steps/dotnet-sonar-prepare.yaml
@@ -1,0 +1,83 @@
+# ── CI Step: SonarCloud Prepare — .NET (MSBuild) ────────────────────────────
+#
+# Inizializza l'analisi SonarCloud in modalità MSBuild per progetti .NET.
+# Da iniettare PRIMA di dotnet-build.yaml.
+# Quando enableSonar è false tutti gli step vengono saltati.
+#
+# Riusato da:
+#   CI/GitFlow/publish-dotNet.yaml
+#   CI/GitFlow/quality-dotNet.yaml
+#   CI/Agnostic/publish-dotNet.yaml
+#   CI/Agnostic/quality-dotNet.yaml
+#   CI/TrunkFlow/publish-dotNet.yaml
+#
+# Parametri
+# ─────────
+#   enableSonar            → abilita l'analisi (default: false)
+#   sonarServiceConnection → nome della Service Connection ADO di tipo SonarCloud
+#   sonarOrganization      → nome organizzazione SonarCloud
+#   sonarProjectKey        → chiave univoca del progetto SonarCloud
+#   sonarExtraProperties   → proprietà aggiuntive (es. coverage report path)
+#
+# Coverage .NET:
+#   sonarExtraProperties: 'sonar.cs.cobertura.reportsPaths=$(Agent.TempDirectory)/**/coverage.cobertura.xml'
+#
+# ─────────────────────────────────────────────────────────────────────────────
+
+parameters:
+  - name: enableSonar
+    type: boolean
+    default: false
+
+  - name: sonarServiceConnection
+    type: string
+    default: ''
+
+  - name: sonarOrganization
+    type: string
+    default: ''
+
+  - name: sonarProjectKey
+    type: string
+    default: ''
+
+  - name: sonarExtraProperties
+    type: string
+    default: ''
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+steps:
+  - ${{ if parameters.enableSonar }}:
+    - script: |
+        set -euo pipefail
+
+        service_connection='${{ parameters.sonarServiceConnection }}'
+        organization='${{ parameters.sonarOrganization }}'
+        project_key='${{ parameters.sonarProjectKey }}'
+
+        if [[ -z "${service_connection// }" ]]; then
+          echo "ERROR: 'sonarServiceConnection' is required when SonarCloud analysis is enabled."
+          exit 1
+        fi
+
+        if [[ -z "${organization// }" ]]; then
+          echo "ERROR: 'sonarOrganization' is required when SonarCloud analysis is enabled."
+          exit 1
+        fi
+
+        if [[ -z "${project_key// }" ]]; then
+          echo "ERROR: 'sonarProjectKey' is required when SonarCloud analysis is enabled."
+          exit 1
+        fi
+      displayName: 'Validate SonarCloud required parameters'
+
+    - task: SonarCloudPrepare@3
+      displayName: 'SonarCloud Prepare'
+      inputs:
+        SonarCloud: '${{ parameters.sonarServiceConnection }}'
+        organization: '${{ parameters.sonarOrganization }}'
+        scannerMode: 'MSBuild'
+        projectKey: '${{ parameters.sonarProjectKey }}'
+        projectName: '${{ parameters.sonarProjectKey }}'
+        extraProperties: '${{ parameters.sonarExtraProperties }}'

--- a/V3/CI/Common/Steps/dotnet-sonar.yaml
+++ b/V3/CI/Common/Steps/dotnet-sonar.yaml
@@ -1,24 +1,22 @@
-# ── CI Step: SonarCloud — .NET ─────────────────────────────────────────────────
+# ── CI Step: SonarCloud Analyze — .NET (MSBuild) ────────────────────────────
 #
-# Esegue l'analisi SonarCloud completa (Prepare → Analyze → Publish) per
-# progetti .NET in CLI mode. Da iniettare dopo dotnet-test.yaml.
+# Esegue l'analisi SonarCloud (Analyze → Publish) per progetti .NET in
+# modalità MSBuild. Da iniettare DOPO dotnet-build.yaml (e dotnet-test.yaml
+# se disponibile). Richiede che dotnet-sonar-prepare.yaml sia stato iniettato
+# prima di dotnet-build.yaml.
 # Quando enableSonar è false tutti gli step vengono saltati.
 #
 # Riusato da:
+#   CI/GitFlow/publish-dotNet.yaml
 #   CI/GitFlow/quality-dotNet.yaml
+#   CI/Agnostic/publish-dotNet.yaml
 #   CI/Agnostic/quality-dotNet.yaml
+#   CI/TrunkFlow/publish-dotNet.yaml
 #
 # Parametri
 # ─────────
 #   enableSonar            → abilita l'analisi (default: false)
 #   sonarServiceConnection → nome della Service Connection ADO di tipo SonarCloud
-#   sonarOrganization      → nome organizzazione SonarCloud
-#   sonarProjectKey        → chiave univoca del progetto SonarCloud
-#   sonarSources           → cartella sorgenti da analizzare (default: '.')
-#   sonarExtraProperties   → proprietà aggiuntive (es. coverage report path)
-#
-# Coverage .NET:
-#   sonarExtraProperties: 'sonar.cs.cobertura.reportsPaths=$(Agent.TempDirectory)/**/coverage.cobertura.xml'
 #
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -31,61 +29,10 @@ parameters:
     type: string
     default: ''
 
-  - name: sonarOrganization
-    type: string
-    default: ''
-
-  - name: sonarProjectKey
-    type: string
-    default: ''
-
-  - name: sonarSources
-    type: string
-    default: '.'
-
-  - name: sonarExtraProperties
-    type: string
-    default: ''
-
 # ─────────────────────────────────────────────────────────────────────────────
 
 steps:
   - ${{ if parameters.enableSonar }}:
-    - script: |
-        set -euo pipefail
-
-        service_connection='${{ parameters.sonarServiceConnection }}'
-        organization='${{ parameters.sonarOrganization }}'
-        project_key='${{ parameters.sonarProjectKey }}'
-
-        if [[ -z "${service_connection// }" ]]; then
-          echo "ERROR: 'sonarServiceConnection' is required when SonarCloud analysis is enabled."
-          exit 1
-        fi
-
-        if [[ -z "${organization// }" ]]; then
-          echo "ERROR: 'sonarOrganization' is required when SonarCloud analysis is enabled."
-          exit 1
-        fi
-
-        if [[ -z "${project_key// }" ]]; then
-          echo "ERROR: 'sonarProjectKey' is required when SonarCloud analysis is enabled."
-          exit 1
-        fi
-      displayName: 'Validate SonarCloud required parameters'
-
-    - task: SonarCloudPrepare@3
-      displayName: 'SonarCloud Prepare'
-      inputs:
-        SonarCloud: '${{ parameters.sonarServiceConnection }}'
-        organization: '${{ parameters.sonarOrganization }}'
-        scannerMode: 'CLI'
-        configMode: 'manual'
-        cliProjectKey: '${{ parameters.sonarProjectKey }}'
-        cliProjectName: '${{ parameters.sonarProjectKey }}'
-        cliSources: '${{ parameters.sonarSources }}'
-        extraProperties: '${{ parameters.sonarExtraProperties }}'
-
     - task: SonarCloudAnalyze@3
       displayName: 'SonarCloud Analyze'
 

--- a/V3/CI/GitFlow/publish-dotNet.yaml
+++ b/V3/CI/GitFlow/publish-dotNet.yaml
@@ -82,6 +82,12 @@ stages:
       projectName: ${{ parameters.projectName }}
       checkoutRepository: ${{ parameters.checkoutRepository }}
       buildSteps:
+        - template: ../Common/Steps/dotnet-sonar-prepare.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}
         - template: ../Common/Steps/dotnet-build.yaml
           parameters:
             projects: '**/${{ parameters.projectName }}.csproj'
@@ -91,8 +97,6 @@ stages:
           parameters:
             enableSonar: ${{ parameters.enableSonar }}
             sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
-            sonarOrganization: ${{ parameters.sonarOrganization }}
-            sonarProjectKey: ${{ parameters.sonarProjectKey }}
 
       publishSteps:
         - template: ../Common/Steps/dotnet-publish.yaml

--- a/V3/CI/GitFlow/quality-dotNet.yaml
+++ b/V3/CI/GitFlow/quality-dotNet.yaml
@@ -54,6 +54,12 @@ stages:
       gitLeaksNoGit: ${{ parameters.gitLeaksNoGit }}
       buildAndTestSteps:
         - template: ../Common/Steps/dotnet-nuget-check.yaml
+        - template: ../Common/Steps/dotnet-sonar-prepare.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}
         - template: ../Common/Steps/dotnet-build.yaml
           parameters:
             projects: '$(buildProjects)'
@@ -62,5 +68,3 @@ stages:
           parameters:
             enableSonar: ${{ parameters.enableSonar }}
             sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
-            sonarOrganization: ${{ parameters.sonarOrganization }}
-            sonarProjectKey: ${{ parameters.sonarProjectKey }}

--- a/V3/CI/TrunkFlow/publish-dotNet.yaml
+++ b/V3/CI/TrunkFlow/publish-dotNet.yaml
@@ -77,6 +77,12 @@ stages:
       projectName: ${{ parameters.projectName }}
       checkoutRepository: ${{ parameters.checkoutRepository }}
       buildSteps:
+        - template: ../Common/Steps/dotnet-sonar-prepare.yaml
+          parameters:
+            enableSonar: ${{ parameters.enableSonar }}
+            sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
+            sonarOrganization: ${{ parameters.sonarOrganization }}
+            sonarProjectKey: ${{ parameters.sonarProjectKey }}
         - template: ../Common/Steps/dotnet-build.yaml
           parameters:
             projects: '${{ parameters.projectName }}/${{ parameters.projectName }}.csproj'
@@ -86,8 +92,6 @@ stages:
           parameters:
             enableSonar: ${{ parameters.enableSonar }}
             sonarServiceConnection: ${{ parameters.sonarServiceConnection }}
-            sonarOrganization: ${{ parameters.sonarOrganization }}
-            sonarProjectKey: ${{ parameters.sonarProjectKey }}
 
       publishSteps:
         - template: ../Common/Steps/dotnet-publish.yaml


### PR DESCRIPTION
Split dotnet-sonar.yaml into dotnet-sonar-prepare.yaml (SonarCloudPrepare in MSBuild mode, injected before dotnet-build) and dotnet-sonar.yaml (SonarCloudAnalyze + SonarCloudPublish, injected after build/test). Updated all 5 callers across Agnostic, GitFlow, and TrunkFlow flows.