### PR TITLE
fix: upgrade SonarCloud tasks from @3 to @4

### DIFF
--- a/V3/CI/Common/Steps/angular-sonar.yaml
+++ b/V3/CI/Common/Steps/angular-sonar.yaml
@@ -74,7 +74,7 @@ steps:
         fi
       displayName: 'Validate SonarCloud required parameters'
 
-    - task: SonarCloudPrepare@3
+    - task: SonarCloudPrepare@4
       displayName: 'SonarCloud Prepare'
       inputs:
         SonarCloud: '${{ parameters.sonarServiceConnection }}'
@@ -86,10 +86,10 @@ steps:
         cliSources: '${{ parameters.sonarSources }}'
         extraProperties: '${{ parameters.sonarExtraProperties }}'
 
-    - task: SonarCloudAnalyze@3
+    - task: SonarCloudAnalyze@4
       displayName: 'SonarCloud Analyze'
 
-    - task: SonarCloudPublish@3
+    - task: SonarCloudPublish@4
       displayName: 'SonarCloud Publish'
       inputs:
         SonarCloud: '${{ parameters.sonarServiceConnection }}'

--- a/V3/CI/Common/Steps/dotnet-sonar-prepare.yaml
+++ b/V3/CI/Common/Steps/dotnet-sonar-prepare.yaml
@@ -72,7 +72,7 @@ steps:
         fi
       displayName: 'Validate SonarCloud required parameters'
 
-    - task: SonarCloudPrepare@3
+    - task: SonarCloudPrepare@4
       displayName: 'SonarCloud Prepare'
       inputs:
         SonarCloud: '${{ parameters.sonarServiceConnection }}'

--- a/V3/CI/Common/Steps/dotnet-sonar.yaml
+++ b/V3/CI/Common/Steps/dotnet-sonar.yaml
@@ -33,10 +33,10 @@ parameters:
 
 steps:
   - ${{ if parameters.enableSonar }}:
-    - task: SonarCloudAnalyze@3
+    - task: SonarCloudAnalyze@4
       displayName: 'SonarCloud Analyze'
 
-    - task: SonarCloudPublish@3
+    - task: SonarCloudPublish@4
       displayName: 'SonarCloud Publish'
       inputs:
         SonarCloud: '${{ parameters.sonarServiceConnection }}'


### PR DESCRIPTION
SonarCloudPrepare@3, SonarCloudAnalyze@3 and SonarCloudPublish@3 are deprecated. Task structure and input names unchanged in v4.